### PR TITLE
Set wordpress:db:push to roles(:db)

### DIFF
--- a/lib/capistrano/tasks/wordpress.rake
+++ b/lib/capistrano/tasks/wordpress.rake
@@ -30,7 +30,7 @@ namespace :wordpress do
 
     desc "Push the local database"
     task :push do
-      on roles(:web) do
+      on roles(:db) do
 
         run_locally do
           execute :wp, "--path=#{fetch(:wp_path)} db export database.sql"


### PR DESCRIPTION
In order to be consistent with other database tasks, changed wordpress:db:push to look for roles(:db) instead of :web.